### PR TITLE
Fix issue where zone operation miss cooling modes

### DIFF
--- a/app.json
+++ b/app.json
@@ -862,22 +862,36 @@
                 {
                   "id": "0",
                   "label": {
-                    "en": "Room",
+                    "en": "Heat Room",
                     "es": "Termostato"
                   }
                 },
                 {
                   "id": "1",
                   "label": {
-                    "en": "Flow",
+                    "en": "Heat Flow",
                     "es": "Flow"
                   }
                 },
                 {
                   "id": "2",
                   "label": {
-                    "en": "Curve",
+                    "en": "Heat Curve",
                     "es": "Curva"
+                  }
+                },
+                {
+                  "id": "3",
+                  "label": {
+                    "en": "Cool Thermostat",
+                    "es": "Cool Termostato"
+                  }
+                },
+                {
+                  "id": "4",
+                  "label": {
+                    "en": "Cool Flow",
+                    "es": "Cool Flow"
                   }
                 }
               ]

--- a/app.json
+++ b/app.json
@@ -130,22 +130,36 @@
         {
           "id": "0",
           "title": {
-            "en": "Room",
+            "en": "Heat Room",
             "es": "Termostato"
           }
         },
         {
           "id": "1",
           "title": {
-            "en": "Flow",
+            "en": "Heat Flow",
             "es": "Flow"
           }
         },
         {
           "id": "2",
           "title": {
-            "en": "Curve",
+            "en": "Heat Curve",
             "es": "Curva"
+          }
+        },
+        {
+          "id": "3",
+          "title": {
+            "en": "Cool Room",
+            "es": "Termostato"
+          }
+        },
+        {
+          "id": "4",
+          "title": {
+            "en": "Cool Flow",
+            "es": "Termostato"
           }
         }
       ]
@@ -884,14 +898,14 @@
                   "id": "3",
                   "label": {
                     "en": "Cool Thermostat",
-                    "es": "Cool Termostato"
+                    "es": "Termostato"
                   }
                 },
                 {
                   "id": "4",
                   "label": {
                     "en": "Cool Flow",
-                    "es": "Cool Flow"
+                    "es": "Flow"
                   }
                 }
               ]
@@ -1035,22 +1049,36 @@
               {
                 "id": "0",
                 "title": {
-                  "en": "Room",
+                  "en": "Heat Room",
                   "es": "Termostato"
                 }
               },
               {
                 "id": "1",
                 "title": {
-                  "en": "Flow",
+                  "en": "Heat Flow",
                   "es": "Flow"
                 }
               },
               {
                 "id": "2",
                 "title": {
-                  "en": "Curve",
+                  "en": "Heat Curve",
                   "es": "Curva"
+                }
+              },
+              {
+                "id": "3",
+                "title": {
+                  "en": "Cool Room",
+                  "es": "Termostato"
+                }
+              },
+              {
+                "id": "4",
+                "title": {
+                  "en": "Cool Flow",
+                  "es": "Termostato"
                 }
               }
             ]
@@ -1687,22 +1715,36 @@
               {
                 "id": "0",
                 "title": {
-                  "en": "Room",
+                  "en": "Heat Room",
                   "es": "Termostato"
                 }
               },
               {
                 "id": "1",
                 "title": {
-                  "en": "Flow",
+                  "en": "Heat Flow",
                   "es": "Flow"
                 }
               },
               {
                 "id": "2",
                 "title": {
-                  "en": "Curve",
+                  "en": "Heat Curve",
                   "es": "Curva"
+                }
+              },
+              {
+                "id": "3",
+                "title": {
+                  "en": "Cool Room",
+                  "es": "Termostato"
+                }
+              },
+              {
+                "id": "4",
+                "title": {
+                  "en": "Cool Flow",
+                  "es": "Termostato"
                 }
               }
             ]
@@ -2139,22 +2181,36 @@
               {
                 "id": "0",
                 "title": {
-                  "en": "Room",
+                  "en": "Heat Room",
                   "es": "Termostato"
                 }
               },
               {
                 "id": "1",
                 "title": {
-                  "en": "Flow",
+                  "en": "Heat Flow",
                   "es": "Flow"
                 }
               },
               {
                 "id": "2",
                 "title": {
-                  "en": "Curve",
+                  "en": "Heat Curve",
                   "es": "Curva"
+                }
+              },
+              {
+                "id": "3",
+                "title": {
+                  "en": "Cool Room",
+                  "es": "Termostato"
+                }
+              },
+              {
+                "id": "4",
+                "title": {
+                  "en": "Cool Flow",
+                  "es": "Termostato"
                 }
               }
             ]


### PR DESCRIPTION
Current version has issues changing the zone modes to cooling missing Cool Thermostat and Cool Flow modes. This prevents the heating pump to be switched to cooling mode in the settings.

Updated the available zone operation modes based on an unofficial Python API for MelCloud https://github.com/vilppuvuorinen/pymelcloud/blob/e5159b1fae77d55a5a91e4743a791d531e1559da/pymelcloud/atw_device.py#L52

@XattSPT this PR is missing the Spanish translations, please add them if possible