### PR TITLE
Allow water tank temperature to be of a larger range

### DIFF
--- a/app.json
+++ b/app.json
@@ -463,8 +463,8 @@
         "en": "ºC",
         "es": "ºC"
       },
-      "min": 40,
-      "max": 80,
+      "min": 0,
+      "max": 100,
       "step": 0.5,
       "icon": "/assets/tanktemp.svg"
     },


### PR DESCRIPTION
Changes the allowed value range of the water tank from 40-80 C to 0-100 C.

Currently, if the water tank temperature gets below 40 C (like after a long shower) or above 80 C (possible with an external boiler connected) this capability was not able to be set without an exception being thrown.
This will affect the allowed target temperature range since that is controlled by https://github.com/XattSPT/com.melcloud/blob/master/app.json#L902-L903